### PR TITLE
[vacation_sieve] use .vacation class to not mess with the other ui elements

### DIFF
--- a/plugins/vacation_sieve/styles.css
+++ b/plugins/vacation_sieve/styles.css
@@ -1,13 +1,13 @@
 
 /* Section headers for the orms */
-td.section-first
+.vacation td.section-first
 {
     font-size:larger;
     font-weight:bold;
     padding-bottom:4pt;
 }
 
-td.section
+.vacation td.section
 {
     font-size:larger;
     font-weight:bold;
@@ -15,7 +15,7 @@ td.section
     padding-bottom:4pt;
 }
 
-td.top
+.vacation td.top
 {
     vertical-align:top;
 }

--- a/plugins/vacation_sieve/vacation_sieve.php
+++ b/plugins/vacation_sieve/vacation_sieve.php
@@ -286,7 +286,7 @@ class vacation_sieve extends rcube_plugin
     {
         try
         {
-            $table = new html_table(array('cols' => 2, 'class' => 'propform'));
+            $table = new html_table(array('cols' => 2, 'class' => 'propform vacation'));
 
             $format = $this->app->config->get('date_format');
 


### PR DESCRIPTION
use .vacation class to not mess with the other ui elements

picket from https://github.com/raoulbhatia/arodier-roundcube-plugins/commit/9030bb84920800e8e5fcea50bd3cd680b3fc6d54